### PR TITLE
Integrate resume for job applications

### DIFF
--- a/job_preferences.json
+++ b/job_preferences.json
@@ -19,5 +19,5 @@
     "React",
     "AWS"
   ],
-  "selected_resume": "resume1.pdf"
+  "selected_resume": "Resume"
 }

--- a/linkedin_browser_mcp.py
+++ b/linkedin_browser_mcp.py
@@ -643,6 +643,24 @@ async def apply_to_linkedin_job(job_url: str, ctx: Context, resume_path: str = '
             # Wait for application modal
             await page.wait_for_selector('.jobs-easy-apply-modal', timeout=5000)
             
+            # Handle resume upload if path is provided
+            if resume_path and os.path.exists(resume_path):
+                try:
+                    ctx.info(f"Uploading resume from: {resume_path}")
+                    # This selector is a guess and may need to be adjusted.
+                    # It looks for a file input that is not disabled.
+                    file_input_selector = 'input[type="file"]:not(:disabled)'
+                    await page.wait_for_selector(file_input_selector, timeout=5000)
+                    file_chooser = await page.query_selector(file_input_selector)
+                    if file_chooser:
+                        await file_chooser.set_input_files(resume_path)
+                        ctx.info("Resume uploaded successfully.")
+                        report_progress(ctx, 70, 100, "Resume uploaded")
+                    else:
+                        ctx.warning("Could not find resume upload button.")
+                except Exception as upload_error:
+                    ctx.warning(f"Failed to upload resume: {str(upload_error)}")
+
             # Handle application steps (simplified - just submit if possible)
             try:
                 # Look for submit button

--- a/resumes/Resume.pdf
+++ b/resumes/Resume.pdf
@@ -1,0 +1,1 @@
+This is a dummy resume.


### PR DESCRIPTION
Enable job application with a local resume by adding file upload functionality and configuring the default resume.

The original `apply_to_linkedin_job` function in `linkedin_browser_mcp.py` did not support uploading a local resume file, relying only on LinkedIn's pre-filled resume. This PR adds the necessary Playwright `set_input_files` logic to allow users to upload a specified resume during the "Easy Apply" process. A placeholder `Resume.pdf` was created as the original file was not found.